### PR TITLE
log -> logrus

### DIFF
--- a/internal/az/resourceproviders/cache.go
+++ b/internal/az/resourceproviders/cache.go
@@ -2,7 +2,7 @@ package resourceproviders
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/resources/mgmt/resources"
 )

--- a/internal/az/resourceproviders/registration.go
+++ b/internal/az/resourceproviders/registration.go
@@ -3,7 +3,7 @@ package resourceproviders
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"sync"
 

--- a/internal/common/correlation_id.go
+++ b/internal/common/correlation_id.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 
 	"github.com/Azure/go-autorest/autorest"

--- a/internal/locks/mutexkv.go
+++ b/internal/locks/mutexkv.go
@@ -1,7 +1,7 @@
 package locks
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 )
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"os"
 	"strings"

--- a/internal/services/compute/availability_set_resource.go
+++ b/internal/services/compute/availability_set_resource.go
@@ -2,7 +2,7 @@ package compute
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/internal/services/compute/image_data_source.go
+++ b/internal/services/compute/image_data_source.go
@@ -2,7 +2,7 @@ package compute
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"sort"
 	"time"

--- a/internal/services/compute/image_resource.go
+++ b/internal/services/compute/image_resource.go
@@ -2,7 +2,7 @@ package compute
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -2,7 +2,7 @@ package compute
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"time"

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -2,7 +2,7 @@ package compute
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"

--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -2,7 +2,7 @@ package compute
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/services/compute/ssh_keys.go
+++ b/internal/services/compute/ssh_keys.go
@@ -3,7 +3,7 @@ package compute
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"

--- a/internal/services/compute/virtual_machine_data_disk_attachment_resource.go
+++ b/internal/services/compute/virtual_machine_data_disk_attachment_resource.go
@@ -2,7 +2,7 @@ package compute
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"

--- a/internal/services/compute/virtual_machine_resource.go
+++ b/internal/services/compute/virtual_machine_resource.go
@@ -6,7 +6,7 @@ import (
 	"crypto/sha1" // nolint:gosec
 	"encoding/hex"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/services/compute/virtual_machine_scale_set_extension_resource.go
+++ b/internal/services/compute/virtual_machine_scale_set_extension_resource.go
@@ -2,7 +2,7 @@ package compute
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"

--- a/internal/services/compute/virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/virtual_machine_scale_set_resource.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/services/compute/virtual_machine_scale_set_update.go
+++ b/internal/services/compute/virtual_machine_scale_set_update.go
@@ -3,7 +3,7 @@ package compute
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -2,7 +2,7 @@ package compute
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"time"

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -2,7 +2,7 @@ package compute
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/compute/mgmt/compute"

--- a/internal/services/dns/migration/dns_zone_V0_to_V1.go
+++ b/internal/services/dns/migration/dns_zone_V0_to_V1.go
@@ -3,7 +3,7 @@ package migration
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-provider-azurestack/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurestack/internal/services/dns/parse"

--- a/internal/services/keyvault/internal.go
+++ b/internal/services/keyvault/internal.go
@@ -3,7 +3,7 @@ package keyvault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"

--- a/internal/services/keyvault/key_vault_access_policy_resource.go
+++ b/internal/services/keyvault/key_vault_access_policy_resource.go
@@ -3,7 +3,7 @@ package keyvault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -2,7 +2,7 @@ package keyvault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"strings"
 	"time"

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -3,7 +3,7 @@ package keyvault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"

--- a/internal/services/loadbalancer/loadbalancer_backend_address_pool_resource.go
+++ b/internal/services/loadbalancer/loadbalancer_backend_address_pool_resource.go
@@ -2,7 +2,7 @@ package loadbalancer
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"

--- a/internal/services/loadbalancer/loadbalancer_nat_pool_resource.go
+++ b/internal/services/loadbalancer/loadbalancer_nat_pool_resource.go
@@ -2,7 +2,7 @@ package loadbalancer
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"

--- a/internal/services/loadbalancer/loadbalancer_nat_rule_resource.go
+++ b/internal/services/loadbalancer/loadbalancer_nat_rule_resource.go
@@ -2,7 +2,7 @@ package loadbalancer
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"

--- a/internal/services/loadbalancer/loadbalancer_probe_resource.go
+++ b/internal/services/loadbalancer/loadbalancer_probe_resource.go
@@ -2,7 +2,7 @@ package loadbalancer
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"

--- a/internal/services/loadbalancer/loadbalancer_resource.go
+++ b/internal/services/loadbalancer/loadbalancer_resource.go
@@ -3,7 +3,7 @@ package loadbalancer
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"

--- a/internal/services/loadbalancer/loadbalancer_rule_data_source.go
+++ b/internal/services/loadbalancer/loadbalancer_rule_data_source.go
@@ -2,7 +2,7 @@ package loadbalancer
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"

--- a/internal/services/loadbalancer/loadbalancer_rule_resource.go
+++ b/internal/services/loadbalancer/loadbalancer_rule_resource.go
@@ -2,7 +2,7 @@ package loadbalancer
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"

--- a/internal/services/network/loadbalancer_backend_address_pool_association_resource.go
+++ b/internal/services/network/loadbalancer_backend_address_pool_association_resource.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/services/network/public_ips_data_source.go
+++ b/internal/services/network/public_ips_data_source.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/services/network/route_table_resource.go
+++ b/internal/services/network/route_table_resource.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -3,7 +3,7 @@ package network
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/network/mgmt/network"

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -3,7 +3,7 @@ package network
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/services/network/virtual_network_peering_resource.go
+++ b/internal/services/network/virtual_network_peering_resource.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"sync"
 	"time"

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"time"
 

--- a/internal/services/resource/resource_arm_template_deployment.go
+++ b/internal/services/resource/resource_arm_template_deployment.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"time"

--- a/internal/services/resource/resource_arm_template_deployment_test.go
+++ b/internal/services/resource/resource_arm_template_deployment_test.go
@@ -3,7 +3,7 @@ package resource_test
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strconv"
 	"testing"

--- a/internal/services/resource/resource_group_resource.go
+++ b/internal/services/resource/resource_group_resource.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/resources/mgmt/resources"

--- a/internal/services/resource/resources_data_source.go
+++ b/internal/services/resource/resources_data_source.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/services/storage/client/helpers.go
+++ b/internal/services/storage/client/helpers.go
@@ -3,7 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/storage/mgmt/storage"

--- a/internal/services/storage/storage_blob_resource.go
+++ b/internal/services/storage/storage_blob_resource.go
@@ -2,7 +2,7 @@ package storage
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -2,7 +2,7 @@ package storage
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/tf/acceptance/ssh/run.go
+++ b/internal/tf/acceptance/ssh/run.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/internal/tf/pluginsdk/imports.go
+++ b/internal/tf/pluginsdk/imports.go
@@ -3,7 +3,7 @@ package pluginsdk
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/internal/tf/sdk/logger_console.go
+++ b/internal/tf/sdk/logger_console.go
@@ -2,7 +2,7 @@ package sdk
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 var _ Logger = ConsoleLogger{}

--- a/internal/tf/sdk/logger_diagnostics.go
+++ b/internal/tf/sdk/logger_diagnostics.go
@@ -2,7 +2,7 @@ package sdk
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/hashicorp/terraform-provider-azurestack/internal/provider"

--- a/vendor/github.com/Azure/go-autorest/autorest/client.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/client.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"strings"
 	"time"

--- a/vendor/github.com/Azure/go-autorest/autorest/sender.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/sender.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"net"
 	"net/http"

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_msi.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_msi.go
@@ -3,7 +3,7 @@ package authentication
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 
 	"github.com/Azure/go-autorest/autorest"

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/azure_sp_objectid.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/azure_sp_objectid.go
@@ -3,7 +3,7 @@ package authentication
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/http/httputil"
 

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/builder.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/builder.go
@@ -3,7 +3,7 @@ package authentication
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 var authenticatedObjectCache *string

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/config.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/config.go
@@ -3,7 +3,7 @@ package authentication
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest"

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/location/supported.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/location/supported.go
@@ -2,7 +2,7 @@ package location
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 // supportedLocations can be (validly) nil - as such this shouldn't be relied on

--- a/vendor/github.com/hashicorp/go-azure-helpers/sender/sender.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/sender/sender.go
@@ -1,7 +1,7 @@
 package sender
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/http/httputil"
 

--- a/vendor/github.com/hashicorp/go-hclog/interceptlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/interceptlogger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 	"sync/atomic"
 )

--- a/vendor/github.com/hashicorp/go-hclog/intlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/intlogger.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"reflect"
 	"runtime"

--- a/vendor/github.com/hashicorp/go-hclog/logger.go
+++ b/vendor/github.com/hashicorp/go-hclog/logger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 )

--- a/vendor/github.com/hashicorp/go-hclog/nulllogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/nulllogger.go
@@ -3,7 +3,7 @@ package hclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 // NewNullLogger instantiates a Logger for which all calls

--- a/vendor/github.com/hashicorp/go-hclog/stdlog.go
+++ b/vendor/github.com/hashicorp/go-hclog/stdlog.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 )
 

--- a/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/mux_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/mux_broker.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/binary"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/rpc_server.go
+++ b/vendor/github.com/hashicorp/go-plugin/rpc_server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"net/rpc"
 	"sync"

--- a/vendor/github.com/hashicorp/go-plugin/stream.go
+++ b/vendor/github.com/hashicorp/go-plugin/stream.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func copyStream(name string, dst io.Writer, src io.Reader) {

--- a/vendor/github.com/hashicorp/go-retryablehttp/client.go
+++ b/vendor/github.com/hashicorp/go-retryablehttp/client.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"math/rand"
 	"net/http"

--- a/vendor/github.com/hashicorp/hc-install/checkpoint/latest_version.go
+++ b/vendor/github.com/hashicorp/hc-install/checkpoint/latest_version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
 	"runtime"

--- a/vendor/github.com/hashicorp/hc-install/fs/any_version.go
+++ b/vendor/github.com/hashicorp/hc-install/fs/any_version.go
@@ -3,7 +3,7 @@ package fs
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"path/filepath"
 
 	"github.com/hashicorp/hc-install/errors"

--- a/vendor/github.com/hashicorp/hc-install/fs/exact_version.go
+++ b/vendor/github.com/hashicorp/hc-install/fs/exact_version.go
@@ -3,7 +3,7 @@ package fs
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"path/filepath"
 	"time"
 

--- a/vendor/github.com/hashicorp/hc-install/fs/fs.go
+++ b/vendor/github.com/hashicorp/hc-install/fs/fs.go
@@ -2,7 +2,7 @@ package fs
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/hc-install/installer.go
+++ b/vendor/github.com/hashicorp/hc-install/installer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hc-install/errors"

--- a/vendor/github.com/hashicorp/hc-install/internal/build/go_build.go
+++ b/vendor/github.com/hashicorp/hc-install/internal/build/go_build.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"path/filepath"

--- a/vendor/github.com/hashicorp/hc-install/internal/releasesjson/checksum_downloader.go
+++ b/vendor/github.com/hashicorp/hc-install/internal/releasesjson/checksum_downloader.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"strings"
 

--- a/vendor/github.com/hashicorp/hc-install/internal/releasesjson/downloader.go
+++ b/vendor/github.com/hashicorp/hc-install/internal/releasesjson/downloader.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"os"
 	"path/filepath"

--- a/vendor/github.com/hashicorp/hc-install/internal/releasesjson/releases.go
+++ b/vendor/github.com/hashicorp/hc-install/internal/releasesjson/releases.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"strings"
 

--- a/vendor/github.com/hashicorp/hc-install/releases/exact_version.go
+++ b/vendor/github.com/hashicorp/hc-install/releases/exact_version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
 	"time"

--- a/vendor/github.com/hashicorp/hc-install/releases/latest_version.go
+++ b/vendor/github.com/hashicorp/hc-install/releases/latest_version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
 	"sort"

--- a/vendor/github.com/hashicorp/hc-install/releases/releases.go
+++ b/vendor/github.com/hashicorp/hc-install/releases/releases.go
@@ -2,7 +2,7 @@ package releases
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/hc-install/src/src.go
+++ b/vendor/github.com/hashicorp/hc-install/src/src.go
@@ -2,7 +2,7 @@ package src
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	isrc "github.com/hashicorp/hc-install/internal/src"
 )

--- a/vendor/github.com/hashicorp/hcl/v2/doc.go
+++ b/vendor/github.com/hashicorp/hcl/v2/doc.go
@@ -9,7 +9,7 @@
 //     package main
 //
 //     import (
-//     	"log"
+//     	log "github.com/sirupsen/logrus"
 //     	"github.com/hashicorp/hcl/v2/hclsimple"
 //     )
 //

--- a/vendor/github.com/hashicorp/logutils/level.go
+++ b/vendor/github.com/hashicorp/logutils/level.go
@@ -51,7 +51,7 @@ func (f *LevelFilter) Check(line []byte) bool {
 
 func (f *LevelFilter) Write(p []byte) (n int, err error) {
 	// Note in general that io.Writer can receive any byte sequence
-	// to write, but the "log" package always guarantees that we only
+	// to write, but the log "github.com/sirupsen/logrus" package always guarantees that we only
 	// get a single line. We use that as a slight optimization within
 	// this method, assuming we're dealing with a single, complete line
 	// of log data.

--- a/vendor/github.com/hashicorp/terraform-exec/tfexec/terraform.go
+++ b/vendor/github.com/hashicorp/terraform-exec/tfexec/terraform.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"sync"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server/server.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server/server.go
@@ -3,7 +3,7 @@ package tf5server
 import (
 	"context"
 	"errors"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server/server.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server/server.go
@@ -3,7 +3,7 @@ package tf6server
 import (
 	"context"
 	"errors"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/logging.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/logging.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"syscall"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/transport.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/transport.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/http/httputil"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/plugin.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/plugin.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/state.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"regexp"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing_config.go
@@ -3,7 +3,7 @@ package resource
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing_new.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing_new.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/field_reader_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/field_reader_config.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/grpc_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/grpc_provider.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"sync"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/provider.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"sort"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 
 	"github.com/hashicorp/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_data.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_timeout.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_timeout.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/mitchellh/copystructure"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/schema.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/schema.go
@@ -14,7 +14,7 @@ package schema
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"reflect"
 	"regexp"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/internal/plugin/convert/schema.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/internal/plugin/convert/schema.go
@@ -2,7 +2,7 @@ package convert
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"sort"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/plugin/serve.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/plugin/serve.go
@@ -1,7 +1,7 @@
 package plugin
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/terraform/diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/terraform/diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/terraform/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/terraform/state.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"reflect"
 	"sort"

--- a/vendor/github.com/hashicorp/yamux/mux.go
+++ b/vendor/github.com/hashicorp/yamux/mux.go
@@ -3,7 +3,7 @@ package yamux
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"time"
 )

--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"net"
 	"strings"

--- a/vendor/github.com/manicminer/hamilton/internal/utils/base64.go
+++ b/vendor/github.com/manicminer/hamilton/internal/utils/base64.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"encoding/base64"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func Base64DecodeCertificate(clientCertificate string) (pfx []byte) {

--- a/vendor/github.com/mitchellh/go-testing-interface/testing.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing.go
@@ -2,7 +2,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/golang.org/x/crypto/ssh/channel.go
+++ b/vendor/golang.org/x/crypto/ssh/channel.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 )
 

--- a/vendor/golang.org/x/crypto/ssh/handshake.go
+++ b/vendor/golang.org/x/crypto/ssh/handshake.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"sync"
 )

--- a/vendor/golang.org/x/crypto/ssh/mux.go
+++ b/vendor/golang.org/x/crypto/ssh/mux.go
@@ -8,7 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 	"sync/atomic"
 )

--- a/vendor/golang.org/x/crypto/ssh/transport.go
+++ b/vendor/golang.org/x/crypto/ssh/transport.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 // debugTransport if set, will print packet types as they go over the

--- a/vendor/golang.org/x/net/http2/frame.go
+++ b/vendor/golang.org/x/net/http2/frame.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"sync"
 

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -33,7 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"net"
 	"net/http"

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	mathrand "math/rand"
 	"net"

--- a/vendor/golang.org/x/net/http2/write.go
+++ b/vendor/golang.org/x/net/http2/write.go
@@ -7,7 +7,7 @@ package http2
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 

--- a/vendor/golang.org/x/net/internal/timeseries/timeseries.go
+++ b/vendor/golang.org/x/net/internal/timeseries/timeseries.go
@@ -7,7 +7,7 @@ package timeseries // import "golang.org/x/net/internal/timeseries"
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 )
 

--- a/vendor/golang.org/x/net/trace/events.go
+++ b/vendor/golang.org/x/net/trace/events.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"runtime"
 	"sort"

--- a/vendor/golang.org/x/net/trace/histogram.go
+++ b/vendor/golang.org/x/net/trace/histogram.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"sync"
 

--- a/vendor/golang.org/x/net/trace/trace.go
+++ b/vendor/golang.org/x/net/trace/trace.go
@@ -68,7 +68,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/golang.org/x/oauth2/transport.go
+++ b/vendor/golang.org/x/oauth2/transport.go
@@ -6,7 +6,7 @@ package oauth2
 
 import (
 	"errors"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"sync"
 )

--- a/vendor/golang.org/x/text/unicode/bidi/core.go
+++ b/vendor/golang.org/x/text/unicode/bidi/core.go
@@ -6,7 +6,7 @@ package bidi
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 // This implementation is a port based on the reference implementation found at:

--- a/vendor/google.golang.org/appengine/internal/api.go
+++ b/vendor/google.golang.org/appengine/internal/api.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/google.golang.org/appengine/internal/identity_vm.go
+++ b/vendor/google.golang.org/appengine/internal/identity_vm.go
@@ -7,7 +7,7 @@
 package internal
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/google.golang.org/appengine/internal/main_vm.go
+++ b/vendor/google.golang.org/appengine/internal/main_vm.go
@@ -8,7 +8,7 @@ package internal
 
 import (
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/google.golang.org/appengine/internal/net.go
+++ b/vendor/google.golang.org/appengine/internal/net.go
@@ -8,7 +8,7 @@ package internal
 // It is only used for API calls.
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"runtime"
 	"sync"

--- a/vendor/google.golang.org/grpc/grpclog/loggerv2.go
+++ b/vendor/google.golang.org/grpc/grpclog/loggerv2.go
@@ -21,7 +21,7 @@ package grpclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strconv"
 


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)